### PR TITLE
Improve Dockerfile to build complete app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,116 @@
-FROM ubuntu:20.04
+#
+# This Dockerfile builds OpenMemex to run in a docker container.
+# 
+# The container will serve http on container port 3000, and stores user data in a volume at /data.
+#
+# Dockerfile ARGs enable customizing aspects of the resulting image directly from the cli `docker build ...` step:
+#
+# --build-arg LIBTORCH_VERSION=<value>
+# --build-arg LIBTOKENIZERS_VERSION=<value>
+#
 
-# see https://askubuntu.com/questions/909277/avoiding-user-interaction-with-tzdata-when-installing-certbot-in-a-docker-contai
+#
+# Install and setup runtime dependencies
+#
+FROM ubuntu:20.04 as base
+
+# Install apt packages, clearing package cache in same layer
 ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update -qq \
+	&& apt -y install --no-install-recommends curl wget libtesseract-dev tesseract-ocr imagemagick libva-dev snapd chromium-browser libtinfo-dev neovim ripgrep unzip ca-certificates \
+	&& rm -rf /var/cache/apt/lists
 
-RUN apt update -qq
-RUN apt -y install curl wget libtesseract-dev tesseract-ocr imagemagick libva-dev snapd chromium-browser libtinfo-dev neovim ripgrep
-# RUN service snapd start
-# RUN snap install chromium
+# Install libtorch, removing the package download in the same layer
+ARG LIBTORCH_VERSION=1.9.0+cpu-1
+RUN wget -q -O libtorch.deb -q https://github.com/hasktorch/libtorch-binary-for-ci/releases/download/apt/libtorch_${LIBTORCH_VERSION}_amd64.deb \
+	&& dpkg -i libtorch.deb \
+	&& rm libtorch.deb
 
-RUN curl -sSL https://get.haskellstack.org/ | sh
+#
+# Install and setup build & dev dependencies
+# 
+FROM base as build
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-RUN . /root/.cargo/env && curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+# Install haskell
+# TODO: Install a specific version (or range) of haskell stack, specified by an ARG. (e.g. `ARG STACK_VERSION=xyz`)
+ENV PATH="/root/.local/bin:/root/.stack/bin:$PATH"
+RUN curl -sSL https://get.haskellstack.org/ | sh \
+	&& stack setup \
+	&& stack install ormolu ghcid
 
-RUN stack setup
+# Install rust
+# TODO: Install a specific version (or range) of rust, specified by an ARG. (e.g. `ARG RUST_VERSION=abc`)
+ENV PATH="/root/.cargo/bin:$PATH"
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
+	&& curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+# Print out selected & installed versions of dev tools
+RUN cargo --version; wasm-pack --version; stack --version
+
+#
+# Build Rust Frontend
+#
+FROM build as build-rust
+WORKDIR /src
+
+# Dummy build to cache dep builds -- only rebuilds when Cargo.toml changes
+RUN USER=root cargo new --lib frontend
+ADD ./frontend/Cargo.toml ./frontend/Makefile ./frontend/
+RUN cd ./frontend && make build
+
+# Copy all app files over and build, using cache from the previous step
+ADD ./frontend ./frontend/
+RUN cd ./frontend && make build
+
+#
+# Build Haskell Backend
+#
+FROM build as build-haskell
+WORKDIR /app
+
+# Install libtokenizers, and remove download file in the same step
+ARG LIBTOKENIZERS_VERSION=libtokenizers-v0.1
+RUN wget -q -O libtokenizers-linux.zip https://github.com/hasktorch/tokenizers/releases/download/$LIBTOKENIZERS_VERSION/libtokenizers-linux.zip \
+	&& mkdir -p ./deps/tokenizers \
+	&& unzip -p libtokenizers-linux.zip libtokenizers/lib/libtokenizers_haskell.so >./deps/tokenizers/libtokenizers_haskell.so \
+	&& rm libtokenizers-linux.zip
+
+# Copy over all haskell app files
+# TODO: Move haskell files into a dir that is a sibling to the rust dir (./frontend) so this can be done in 1 command
+COPY ./cli ./cli
+COPY ./crawler ./crawler
+COPY ./deps ./deps
+COPY ./experimental ./experimental
+COPY ./server ./server
+COPY ./shared ./shared
+COPY ./stack.yaml ./Setup.hs ./package.json ./openmemex.cabal ./README.md ./LICENSE .
+
+# Run stack build; this seems to download and install and compile ghc every time
+# TODO: figure out how to move ghc setup into the 'base' layer
+RUN stack build cli && stack build openmemex:server --ghc-options="-O2"
+
+#
+# Package together the outputs from both the rust and haskell stages
+#
+# Having the previous stages start from the 'build' stage indpendently means that either part of the projct that has 
+# been built before will build instantly, by resolving directly from the docker cache which is keyed on on the hash 
+# of all the input files.
+#
+# TODO: Create the final / output stage from the 'base' stage, omitting dev dependencies. This should be possible
+# since everything is statically compiled.
+FROM build-haskell as final
+
+COPY --from=build-rust /src/frontend/static /app/static
+ADD startup.sh /app
+RUN chmod +x /app/startup.sh
+RUN find
+
+EXPOSE 3000
+# TODO: Adjust the backend to accept a parameter for the data storage dir, and set it to /data in startup.sh.
+# Using a volume will automatically persist data for docker users by default, clearly communicates and simplifies
+# customization of the storage location, enables easy version upgrades by attaching the data volume from the previous
+# container in a new container running the newer-version image, and facilitates compact backups of user data.
+VOLUME /data
+
+CMD ["/app/startup.sh"]
+

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -x # enable xtrace
+cd /app
+
+HASKTORCH_LIB_PATH="$(pwd)/libtorch/lib/"
+LD_LIBRARY_PATH=$HASKTORCH_LIB_PATH:$(pwd)/deps/tokenizers:$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH
+
+stack run server
+


### PR DESCRIPTION
Hi! I made some changes to the dockerfile, but I'm still running into a couple issues.

With this PR I'm aiming to deliver:

* No host deps (besides docker) one-shot builds
* ~Virtually instant incremental rebuilds~
* ~Minimize image size (at least minimized delta from ubuntu:20.04)~
* No setup on first run
* ~User data exclusively contained in docker volume~
* ~App able to run with read-only root (except user data volume ofc)~

Here's a list of changes:

* Build rust frontend
* Use a separate docker layer to build frontend deps; this reduces rebuild times when Cargo.toml is not changed to 0.2s (!)
* Combine separate steps into one to reduce disk usage
* Use 'multiple FROM' build strategy to reduce dependencies between layers which improves layer caching performance
* Do haskell build (WIP)
* Build app and static files in a build stage then copy the binaries to the final image to minimize image distribution size (WIP)
* Begin to use /app for program files, use /data for data files backed by a docker VOLUME. This has both security and operational benefits. (WIP)
* Add startup.sh script to do initalization and startup work (WIP)

There are still some things to do:

* Haskell build does not do a separate "build deps" step a la rust. Ideally deps could be built first if possible, which would be cached for fast rebuilds
* Haskell build is spread out between multiple dirs, so requires many COPY steps. Ideally all the haskell code would be in one dir
* startup.sh does not yet initialize empty db on first run
* /app doesn't have all required binaries
* App doesn't use /data for storage yet

Specifically, I'm running into an error with libtorch. I suspect that you may know what's wrong by just looking at the error and dockerfile:

```
libtorch-ffi                     > Configuring libtorch-ffi-1.9.0.0...
libtorch-ffi                     > Cabal-simple_mPHDZzAJ_3.2.1.0_ghc-8.10.4: Missing dependencies on foreign
libtorch-ffi                     > libraries:
libtorch-ffi                     > * Missing (or bad) C libraries: c10, torch, torch_cpu
libtorch-ffi                     > This problem can usually be solved by installing the system packages that
libtorch-ffi                     > provide these libraries (you may need the "-dev" versions). If the libraries
libtorch-ffi                     > are already installed but in a non-standard location then you can use the
libtorch-ffi                     > flags --extra-include-dirs= and --extra-lib-dirs= to specify where they are.If
libtorch-ffi                     > the library files do exist, it may contain errors that are caught by the C
libtorch-ffi                     > compiler at the preprocessing stage. In this case you can re-run configure
libtorch-ffi                     > with the verbosity flag -v3 to see the error messages.
libtorch-ffi                     > 
```