### PR TITLE
fix unique index bug, auto-create database file, fix timeline quantiz…

### DIFF
--- a/frontend/src/app.rs
+++ b/frontend/src/app.rs
@@ -22,6 +22,11 @@ use chrono::*;
 pub type Link = RouterAnchor<AppRoute>;
 
 #[derive(Debug)]
+pub struct Config {
+    tag_threshold: i32,
+}
+
+#[derive(Debug)]
 pub struct App {
     cache_task: Option<FetchTask>,
     tag_task: Option<FetchTask>,
@@ -34,6 +39,7 @@ pub struct App {
     default_query: String,
     query: String,
     search_query: String,
+    config: Config,
 }
 
 #[derive(Debug)]
@@ -124,6 +130,7 @@ impl Component for App {
             default_query: default_query.clone(),
             query: default_query.clone(),
             search_query: String::from(""),
+            config: Config { tag_threshold: 10 },
         }
     }
 
@@ -153,7 +160,7 @@ impl Component for App {
                 self.cache_task = Some(task);
                 // define request
                 log::info!("submitting tag request");
-                let request = Request::get(format!("http://{}/all/tags?min=10", server))
+                let request = Request::get(format!("http://{}/all/tags?min={}", server, self.config.tag_threshold))
                     .body(Nothing)
                     .expect("Could not build request.");
                 // define callback

--- a/frontend/src/timeline.rs
+++ b/frontend/src/timeline.rs
@@ -124,6 +124,12 @@ impl Component for Timeline {
                             .map(|x| 100.0 * (((x as f32) - minf) / (maxf - minf)))
                             .collect();
                         self.utc_range = (min, max);
+
+                        let window = web_sys::window().expect("no global `window` exists");
+                        let document = window.document().expect("should have a document on window");
+                        let timeline = document.get_element_by_id("timeline-svg").expect("get element by id shouldn't fail");
+                        let width = timeline.client_width();
+                        self.time_coord = width;
                     }
                     Err(error) => {
                         log::info!("timeline error:");
@@ -202,10 +208,10 @@ impl Component for Timeline {
             self.link.callback(move |m| TimelineMsg::Click(m))
         };
 
-        let stroke = "stroke:rgb(0,0,0,0.3); stroke-width:2";
-        let cursor_style = "stroke:rgb(0,0,0,0.3); stroke-width:32";
+        let stroke = "stroke:rgb(0,0,0,0.1); stroke-width:2";
+        let cursor_style = "stroke:rgb(0,0,0,0.1); stroke-width:64";
         let data_style = "stroke:rgb(0,0,0,0.1); fill:rgb(0,0,0,0.1)";
-        let text_style = "font: 13px sans-serif; opacity: 0.3;";
+        let text_style = "font: 13px sans-serif; opacity: 0.4;";
 
         html! {
             <div>
@@ -228,15 +234,15 @@ impl Component for Timeline {
                     <line x1="100%" y1="20" x2="100%" y2="30" style=stroke />
 
                     // cursor
-                    <line x1=self.time_coord.to_string()  y1="0%" 
+                    <line x1=self.time_coord.to_string()  y1="30%" 
                      x2=self.time_coord.to_string() y2="100%" style=cursor_style />
 
                      // date annotation
-                    <text x=(self.time_coord + 16).to_string()  y="20%" style=text_style>
+                    <text x=(self.time_coord - 32).to_string()  y="20%" style=text_style>
                     {
                         match &self.time_window {
                             Some((start, end)) => {
-                                start.format("%Y-%m-%d").to_string()
+                                start.format("%Y.%m.%d").to_string()
                             }
                             None => { "".to_string() }
                         }
@@ -247,7 +253,7 @@ impl Component for Timeline {
                     {
                         for self.locations.iter().map(move |loc| {
                             html! {
-                                <circle cx=format!("{:.0}%", loc) cy="50%" r="2" style=data_style />
+                                <circle cx=format!("{:.2}%", loc) cy="50%" r="2" style=data_style />
                             }
                         })
                     }

--- a/server/API.hs
+++ b/server/API.hs
@@ -13,6 +13,15 @@ import Data.Text (Text, pack, unpack)
 import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics (Generic)
 
+data ServerConfig = ServerConfig {
+  tagThreshold :: Int,
+  dbFilename :: String
+}
+
+defaultConfig = ServerConfig {
+  tagThreshold = 10,
+  dbFilename = "openmemex.db"
+}
 
 data PostSearch =
   PostSearch { psQuery :: String } deriving (Show, Generic)

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 
+import Control.Monad (when)
 import Data.Int (Int64)
 import Data.Time ( Day(..), TimeOfDay(..), UTCTime(..))
 import Data.Text (Text)
@@ -20,6 +21,7 @@ import Network.Wai.Logger (withStdoutLogger)
 -- import Network.Wai.Middleware.Cors (simpleCors)
 import Servant
 import System.IO (hPutStrLn, stderr)
+import System.Directory (doesFileExist)
 
 import DB
 import Torch
@@ -133,6 +135,12 @@ mkApp = pure $ serve combinedApi server
 
 runServer :: IO ()
 runServer = do
+  let config = defaultConfig
+  let dbFile = dbFilename config
+  check <- doesFileExist dbFile
+  when (not check) $ do
+    putStrLn $ "Database file " ++ dbFile ++ " not found. Creating a new database file."
+    initDB'
   let port = 3000
   withStdoutLogger $ \aplogger -> do
     let settings =

--- a/shared/SQL.hs
+++ b/shared/SQL.hs
@@ -98,9 +98,9 @@ data Index = Index {
 createIndex :: Index -> ReaderT Sqlite IO ()
 createIndex Index{..} = do
   if indexUnique then
-    bracketExecute $ "CREATE INDEX " ++ indexName ++ " on " ++ indexTable ++ "(" ++ indexField ++ ");"
-  else
     bracketExecute $ "CREATE UNIQUE INDEX " ++ indexName ++ " on " ++ indexTable ++ "(" ++ indexField ++ ");"
+  else
+    bracketExecute $ "CREATE INDEX " ++ indexName ++ " on " ++ indexTable ++ "(" ++ indexField ++ ");"
 
 -- | Create indices
 createIndices :: [Index] -> ReaderT Sqlite IO ()


### PR DESCRIPTION
- Fix quantization bug in timeline
- Automatically create a database file when the server starts if it doesn't exist
- Fix index creation + database initialization bug (previously unique indies and non-unique indices were flipped, leading to inability to add entries)
- Timeline cursor visual tweaks
- Get rid of client-side hard coded minimum # entries to show a tag visually. It's now parameterized from a configuration structure.
- WIP create a data structure for server configuration