### PR TITLE
add command line arguments to server

### DIFF
--- a/openmemex.cabal
+++ b/openmemex.cabal
@@ -31,7 +31,7 @@ executable omx
 executable server
   hs-source-dirs:      server, shared
   main-is:             Main.hs
-  other-modules:       DB, OCR, Models, SQL, CrawlTools, Date, API
+  other-modules:       DB, OCR, Models, SQL, CrawlTools, Date, API, ArgParser
   default-language:    Haskell2010
   build-depends:       base >= 4.7 && < 5
                      , aeson
@@ -41,6 +41,8 @@ executable server
                      , hasktorch
                      , mtl
                      , network-uri
+                     , optparse-applicative
+                     , optparse-generic
                      , pretty-simple
                      , process >= 1.6.9.0
                      , scalpel

--- a/server/API.hs
+++ b/server/API.hs
@@ -13,16 +13,6 @@ import Data.Text (Text, pack, unpack)
 import Data.Aeson (FromJSON, ToJSON)
 import GHC.Generics (Generic)
 
-data ServerConfig = ServerConfig {
-  tagThreshold :: Int,
-  dbFilename :: String
-}
-
-defaultConfig = ServerConfig {
-  tagThreshold = 10,
-  dbFilename = "openmemex.db"
-}
-
 data PostSearch =
   PostSearch { psQuery :: String } deriving (Show, Generic)
 instance ToJSON PostSearch

--- a/server/ArgParser.hs
+++ b/server/ArgParser.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE DeriveGeneric #-}
+
+module ArgParser where
+
+import Control.Applicative
+import Data.Semigroup ((<>))
+import Options.Applicative
+import Data.Aeson (FromJSON, ToJSON)
+import GHC.Generics(Generic)
+
+data Configuration = Configuration
+  { showTagThresh :: Int,
+    port :: Int,
+    dbFilename :: String
+  } deriving (Show, Generic)
+
+instance ToJSON Configuration
+instance FromJSON Configuration
+
+commandLine :: Parser Configuration
+commandLine =
+  Configuration
+    <$> option auto
+      ( long "tag_thresh"
+          <> help "Threshold for minimum number of memex entries of a tag to display it in the gallery."
+          <> showDefault
+          <> value 1
+          <> metavar "INT"
+      )
+    <*> option auto
+      ( long "port"
+          <> help "Server port."
+          <> showDefault
+          <> value 3000
+          <> metavar "INT"
+      )
+    <*> strOption
+          ( long "dbfile"
+         <> help "SQLite database file." 
+          <> metavar "FILENAME"
+         <> showDefault
+         <> value "openmemex.db"
+         )
+
+
+optionsParser :: ParserInfo Configuration
+optionsParser =
+  info
+    (helper <*> commandLine)
+        (header "OpenMemex: An open source, local-first knowledge platform.")
+          


### PR DESCRIPTION
Adds:
- Command line parser
- Configuration data type
- Read port, minimum number of entries to show tag (note - client-side support remains to be implemented), and database file name from configuration.