### PR TITLE
frontend support for configuration loading

### DIFF
--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -62,6 +62,19 @@ pub struct CompletedPayload {
     pub state: bool,
 }
 
+// configuration
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Config {
+    #[serde(rename(serialize = "showTagThresh", deserialize = "showTagThresh"))]
+    pub show_tag_thresh: i32,
+    #[serde(rename(serialize = "resultsPerPage ", deserialize = "resultsPerPage"))]
+    pub results_per_page: i32,
+    #[serde(rename(serialize = "port", deserialize = "port"))]
+    pub port: i32,
+    #[serde(rename(serialize = "dbFilename", deserialize = "dbFilename"))]
+    pub db_filename: String,
+}
+
 pub struct CompletedResponse {
     pub code: i64,
 }

--- a/server/ArgParser.hs
+++ b/server/ArgParser.hs
@@ -10,6 +10,7 @@ import GHC.Generics(Generic)
 
 data Configuration = Configuration
   { showTagThresh :: Int,
+    resultsPerPage :: Int,
     port :: Int,
     dbFilename :: String
   } deriving (Show, Generic)
@@ -27,6 +28,14 @@ commandLine =
           <> value 1
           <> metavar "INT"
       )
+    <*> option auto
+      ( long "results_per_page"
+          <> help "Maximum number of results to show on a page."
+          <> showDefault
+          <> value 150
+          <> metavar "INT"
+      )
+
     <*> option auto
       ( long "port"
           <> help "Server port."

--- a/server/Main.hs
+++ b/server/Main.hs
@@ -6,6 +6,7 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TypeOperators #-}
 
+import Control.Monad.IO.Class (liftIO)
 import Control.Monad (when)
 import Data.Int (Int64)
 import Data.Time ( Day(..), TimeOfDay(..), UTCTime(..))
@@ -125,9 +126,10 @@ server config =
     :<|> linkEntryTagsH
     :<|> helloTorchH
     :<|> helloHuggingfaceH
-    :<|> configH
+    :<|> (configH config)
 
-configH = undefined
+configH :: Configuration -> Handler [Configuration]
+configH config = liftIO $ pure [config]
 
 instance FromHttpApiData SortBy where
   parseUrlPiece value = case value of


### PR DESCRIPTION
Add frontend support to use server command line configuration options:

![image](https://user-images.githubusercontent.com/20875313/142345346-33ee44eb-d2e7-4be1-83bf-6ddf86fcf6a9.png)

- showTagThresh: minimum number of items to show a tag on the gallery page. This defaults to 1, but if there are a lot of tags, you may want to set this to a higher value to show only the most common tags.
- resultsPerPage: maximum number of items to show in the gallery, defaults to 150
- port: the server port, defaults to 3000
- dbFilename: the filename for the sqlite database.

To get help run
`
stack run server -- --help 
`

Example server usage:
`
stack run server -- --tag_thresh 10 --port 4000
`